### PR TITLE
fixing the hubs

### DIFF
--- a/ATAC_hub.txt
+++ b/ATAC_hub.txt
@@ -4,7 +4,7 @@ longLabel Gathering data from ATACseq data during fly embryogenesis.
 useOneFile on
 email mannerviklab@gmail.com
 
-Genome dm6
+genome dm6
 
 track NC11_9min_ATAC_rep1
 shortLabel NC11_9min_ATAC_rep1

--- a/PRO_hub.txt
+++ b/PRO_hub.txt
@@ -1,4 +1,4 @@
-PRO-seq hub flyEmbrygonesis 
+hub flyEmbrygonesis PRO-seq 
 shortLabel PRO-seq Drosophila melanogaster embryo development.
 longLabel Gathering data from PROseq data during fly embryogenesis.
 useOneFile on

--- a/PRO_hub.txt
+++ b/PRO_hub.txt
@@ -4,7 +4,7 @@ longLabel Gathering data from PROseq data during fly embryogenesis.
 useOneFile on
 email mannerviklab@gmail.com
 
-Genome dm6
+genome dm6
 
 track PRO_rep1_Plus_gd7_3h
 shortLabel PRO_rep1_Plus_gd7_3h mutant


### PR DESCRIPTION
In proseq the hub line was wrong and Genome was with a capital G
In ATACseq the genome was also with a capital G.

All has changed and they work for me now in the uscs browser